### PR TITLE
Fix `make install` not working

### DIFF
--- a/makefile
+++ b/makefile
@@ -120,7 +120,7 @@ DESTDIR:=
 PREFIX:=/usr/local
 bindir:=$(DESTDIR)$(PREFIX)/bin
 .PHONY: install
-install: M2-Mesoplanet
+install: bin/M2-Mesoplanet
 	mkdir -p $(bindir)
 	cp $^ $(bindir)
 


### PR DESCRIPTION
I may just be misunderstanding make but running `make install` does not work for me since the file `M2-Mesoplanet` does not exist. `make` creates the file in `bin/M2-Mesoplanet` so this makes sense.

In M2-Planet the makefile also says `install: bin/M2-Planet`.

@stikonas @oriansj 