### PR TITLE
Add lookup in directory of file after current working directory

### DIFF
--- a/cc_reader.c
+++ b/cc_reader.c
@@ -403,7 +403,27 @@ int include_file(int ch, int include_file)
 			strcat(hold_string, "/bootstrappable.h");
 			new_file = fopen(hold_string, "r");
 		}
-		else new_file = fopen(new_filename+1, "r");
+		else
+		{
+			/* Looks up in the current working directory.
+			 * This isn't _really_ compatible with GCC since it only looks in the
+			 * directory of the current file, but it's kept as backwards compatibility.
+			 *
+			 * Arguably this behavior isn't very intuitive since attempting to compile
+			 * a project from a different working directory can lead to including different
+			 * files resulting in a different executable.
+			 * */
+			new_file = fopen(new_filename+1, "r");
+			if(new_file == NULL)
+			{
+				reset_hold_string();
+				strcat(hold_string, file);
+				char* filename_separator = strrchr(hold_string, '/');
+				filename_separator[1] = '\0';
+				strcat(hold_string, new_filename + 1);
+				new_file = fopen(hold_string, "r");
+			}
+		}
 
 		strcat(new_filename, "\"");
 	}

--- a/makefile
+++ b/makefile
@@ -108,6 +108,7 @@ results:
 test: M2-Mesoplanet
 	./test/test0000/run_test.sh
 	./test/test0001/run_test.sh
+	./test/test0002/run_test.sh
 	./test/test0003/run_test.sh
 #	sha256sum -c test/test.answers
 

--- a/makefile
+++ b/makefile
@@ -116,7 +116,10 @@ test: M2-Mesoplanet
 # Generate test answers
 .PHONY: Generate-test-answers
 Generate-test-answers:
-	sha256sum test/results/* >| test/test.answers
+	sha256sum test/test0000/tmp/return.c >| test/test0000/proof.answer
+	sha256sum test/test0001/tmp/return.c >| test/test0001/proof.answer
+	sha256sum test/test0002/tmp/macro_functions.c >| test/test0002/proof.answer
+	sha256sum test/test0003/tmp/include_paths1.c >| test/test0003/proof.answer
 
 DESTDIR:=
 PREFIX:=/usr/local

--- a/makefile
+++ b/makefile
@@ -108,6 +108,7 @@ results:
 test: M2-Mesoplanet
 	./test/test0000/run_test.sh
 	./test/test0001/run_test.sh
+	./test/test0003/run_test.sh
 #	sha256sum -c test/test.answers
 
 

--- a/test/test0002/proof.answer
+++ b/test/test0002/proof.answer
@@ -1,1 +1,1 @@
-9aa535db4d55f66b4ebc5139fbac91127afe24c00c5422e9c15f0391189f8ca5  test/test0002/tmp/macro_functions.c
+9288aba747a092ea8890b571642f8f17882f6c13cbc992dd024dacc5b64ef2bc  test/test0002/tmp/macro_functions.c

--- a/test/test0003/f.h
+++ b/test/test0003/f.h
@@ -1,0 +1,2 @@
+
+int f() { return 0; }

--- a/test/test0003/include_paths1.c
+++ b/test/test0003/include_paths1.c
@@ -1,0 +1,6 @@
+
+#include "f.h"
+
+int main() {
+  return f();
+}

--- a/test/test0003/proof.answer
+++ b/test/test0003/proof.answer
@@ -1,0 +1,1 @@
+0e466d3bc7892fb7347fe195b4b24c103e0d5d24e61c72d15d3594c4d2e60f50  test/test0003/tmp/include_paths1.c

--- a/test/test0003/run_test.sh
+++ b/test/test0003/run_test.sh
@@ -1,0 +1,33 @@
+#! /bin/sh
+## Copyright (C) 2017 Jeremiah Orians
+## Copyright (C) 2020-2021 deesix <deesix@tuta.io>
+## This file is part of M2-Planet.
+##
+## M2-Planet is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## M2-Planet is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with M2-Planet.  If not, see <http://www.gnu.org/licenses/>.
+
+set -x
+
+TMPDIR="test/test0003/tmp"
+
+mkdir -p ${TMPDIR}
+
+# Build the test
+bin/M2-Mesoplanet \
+	-E \
+	-f test/test0003/include_paths1.c \
+	-o ${TMPDIR}/include_paths1.c \
+	|| exit 1
+
+sha256sum -c test/test0003/proof.answer || exit 2
+exit 0


### PR DESCRIPTION
Current behavior only looks up the include in the current working directory which doesn't work for very common patterns such as the test that was added where the CWD is in the repo root.

As mentioned in the comment this isn't very intuitive behavior since compiling with a separate working directory can lead to a different binary which isn't the case for GCC. I didn't want to remove it since it is a feature that people could rely on, but it is IMO a feature that should be removed at the very latest after we get proper `-I` support.

Works on https://github.com/oriansj/M2-Mesoplanet/issues/11.

Also updates M2libc and some fixes for the Makefiles.

@stikonas @oriansj 