### PR TITLE
Add support for `-c`/`.o` files/multi stage compilation

### DIFF
--- a/cc.c
+++ b/cc.c
@@ -339,8 +339,8 @@ int main(int argc, char** argv, char** envp)
 		{
 			if(match(argv[i], "-f") || match(argv[i], "--file"))
 			{
-                            i = i + 1;
-                        }
+				i = i + 1;
+			}
 
 			if(NULL == hold_string)
 			{

--- a/cc.c
+++ b/cc.c
@@ -128,6 +128,11 @@ void prechecks(int argc, char** argv)
 			env = env + 1;
 			i += 2;
 		}
+		else if(match(argv[i], "-c"))
+		{
+			OBJECT_FILES_ONLY = TRUE;
+			i += 1;
+		}
 		else
 		{
 			i += 1;
@@ -163,6 +168,7 @@ int main(int argc, char** argv, char** envp)
 	char* name;
 	int DUMP_MODE = FALSE;
 	follow_includes = TRUE;
+	OBJECT_FILES_ONLY = FALSE;
 
 	/* Try to get our needed updates */
 	prechecks(argc, argv);
@@ -262,6 +268,11 @@ int main(int argc, char** argv, char** envp)
 			/* Handled by precheck */
 			i += 2;
 		}
+		else if(match(argv[i], "-c"))
+		{
+			/* Handled by precheck */
+			i += 1;
+		}
 		else if(match(argv[i], "-h") || match(argv[i], "--help"))
 		{
 			fputs("Usage: M2-Mesoplanet [options] file...\n"
@@ -277,6 +288,7 @@ int main(int argc, char** argv, char** envp)
 				" --dump-mode             Dump tokens before preprocessing\n"
 				" --dirty-mode            Do not remove temporary files\n"
 				" -D                      Add define\n"
+				" -c                      Compile and assemble, but do not link.\n"
 				" -I                      Add M2libc path. Will override the M2LIBC_PATH environment variable.\n"
 				" --fuzz                  Do not execve potentially dangerous inputs\n"
 				" --no-debug              Do not output debug info\n"

--- a/cc.c
+++ b/cc.c
@@ -22,14 +22,14 @@
 
 /* The core functions */
 void populate_env(char** envp);
-void setup_env();
+void setup_env(void);
 char* env_lookup(char* variable);
-void initialize_types();
+void initialize_types(void);
 struct token_list* read_all_tokens(FILE* a, struct token_list* current, char* filename, int include);
 struct token_list* reverse_list(struct token_list* head);
 
 void init_macro_env(char* sym, char* value, char* source, int num);
-void preprocess();
+void preprocess(void);
 void output_tokens(struct token_list *i, FILE* out);
 int strtoint(char *a);
 void spawn_processes(int debug_flag, char* prefix, char* preprocessed_file, char* destination, char** envp, int no_c_files);

--- a/cc.h
+++ b/cc.h
@@ -29,7 +29,7 @@ int in_set(int c, char* s);
 int match(char* a, char* b);
 void require(int bool, char* error);
 char* int2str(int x, int base, int signed_p);
-void reset_hold_string();
+void reset_hold_string(void);
 int ends_with(char* str, char* needle);
 void append_file_contents(FILE* f, FILE* appended_file);
 

--- a/cc.h
+++ b/cc.h
@@ -30,7 +30,8 @@ int match(char* a, char* b);
 void require(int bool, char* error);
 char* int2str(int x, int base, int signed_p);
 void reset_hold_string();
-
+int ends_with(char* str, char* needle);
+void append_file_contents(FILE* f, FILE* appended_file);
 
 struct type
 {
@@ -65,6 +66,12 @@ struct token_list
 		int depth;
 		int linenumber;
 	};
+};
+
+struct object_file_list
+{
+	FILE* file;
+	struct object_file_list* next;
 };
 
 #include "cc_globals.h"

--- a/cc_core.c
+++ b/cc_core.c
@@ -38,7 +38,7 @@ void line_error_token(struct token_list *token)
 	fputs(":", stderr);
 }
 
-void line_error()
+void line_error(void)
 {
 	line_error_token(global_token);
 }

--- a/cc_core.c
+++ b/cc_core.c
@@ -64,3 +64,44 @@ void output_tokens(struct token_list *i, FILE* out)
 		i = i->next;
 	}
 }
+
+int ends_with(char* str, char* needle)
+{
+	size_t str_len = strlen(str);
+	size_t needle_len = strlen(needle);
+
+	return (str_len >= needle_len) && (!memcmp(str + str_len - needle_len, needle, needle_len));
+}
+
+void append_file_contents(FILE* f, FILE* appended_file)
+{
+	const int BUFFER_SIZE = 8192;
+	static char* append_buffer = NULL;
+	if(append_buffer == NULL)
+	{
+		append_buffer = calloc(BUFFER_SIZE, sizeof(char));
+	}
+
+	/* Just in case the appended file doesn't end on a newline */
+	fputs("\n", f);
+
+	size_t read = 0;
+	do
+	{
+		read = fread(append_buffer, sizeof(char), BUFFER_SIZE, appended_file);
+
+		/* Need to know if stdio has been used to choose correct libc. */
+		if(strstr(append_buffer, "__init_malloc") != NULL)
+		{
+			STDIO_USED = TRUE;
+		}
+
+		size_t written = 0;
+		while(written != read)
+		{
+			written = fwrite(append_buffer + written, sizeof(char), read, f);
+		}
+	}
+	while(read != 0);
+}
+

--- a/cc_env.c
+++ b/cc_env.c
@@ -23,7 +23,7 @@ void init_macro_env(char* sym, char* value, char* source, int num);
 char* env_lookup(char* variable);
 void clear_string(char* s);
 
-struct utsname* get_uname_data()
+struct utsname* get_uname_data(void)
 {
 	struct utsname* unameData = calloc(1, sizeof(struct utsname));
 	require(NULL != unameData, "unameData calloc failed\n");
@@ -39,7 +39,7 @@ struct utsname* get_uname_data()
 	return unameData;
 }
 
-void setup_env()
+void setup_env(void)
 {
 	if(2 <= DEBUG_LEVEL) fputs("Starting setup_env\n", stderr);
 	char* ARCH;
@@ -267,7 +267,7 @@ char* env_lookup(char* variable)
 char* envp_hold;
 int envp_index;
 
-void reset_envp_hold()
+void reset_envp_hold(void)
 {
 	clear_string(envp_hold);
 	envp_index = 0;

--- a/cc_globals.c
+++ b/cc_globals.c
@@ -46,6 +46,7 @@ int ENDIAN;
 char* BASEADDRESS;
 int STDIO_USED;
 char* TEMPDIR;
+int OBJECT_FILES_ONLY;
 
 /* So we don't shoot ourself in the face */
 int FUZZING;

--- a/cc_globals.c
+++ b/cc_globals.c
@@ -20,6 +20,8 @@
 struct type* global_types;
 struct type* prim_types;
 
+struct object_file_list* extra_object_files;
+
 /* What we are currently working on */
 struct token_list* global_token;
 

--- a/cc_globals.c
+++ b/cc_globals.c
@@ -16,19 +16,10 @@
  * along with M2-Planet.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* What types we have */
-struct type* global_types;
-struct type* prim_types;
-
 struct object_file_list* extra_object_files;
 
 /* What we are currently working on */
 struct token_list* global_token;
-
-/* Output reorder collections*/
-struct token_list* output_list;
-struct token_list* strings_list;
-struct token_list* globals_list;
 
 /* Make our string collection more efficient */
 char* hold_string;

--- a/cc_globals.h
+++ b/cc_globals.h
@@ -20,6 +20,8 @@
 extern struct type* global_types;
 extern struct type* prim_types;
 
+extern struct object_file_list* extra_object_files;
+
 /* What we are currently working on */
 extern struct token_list* global_token;
 

--- a/cc_globals.h
+++ b/cc_globals.h
@@ -47,6 +47,7 @@ extern int ENDIAN;
 extern char* BASEADDRESS;
 extern int STDIO_USED;
 extern char* TEMPDIR;
+extern int OBJECT_FILES_ONLY;
 
 /* So we don't shoot ourself in the face */
 extern int FUZZING;

--- a/cc_globals.h
+++ b/cc_globals.h
@@ -16,19 +16,10 @@
  * along with M2-Planet.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* What types we have */
-extern struct type* global_types;
-extern struct type* prim_types;
-
 extern struct object_file_list* extra_object_files;
 
 /* What we are currently working on */
 extern struct token_list* global_token;
-
-/* Output reorder collections*/
-extern struct token_list* output_list;
-extern struct token_list* strings_list;
-extern struct token_list* globals_list;
 
 /* Make our string collection more efficient */
 extern char* hold_string;

--- a/cc_macro.c
+++ b/cc_macro.c
@@ -75,12 +75,12 @@ void _eat_current_token(int eat_whitespace)
 		global_token = macro_token;
 }
 
-void eat_current_token()
+void eat_current_token(void)
 {
 	_eat_current_token(TRUE);
 }
 
-void eat_current_token_without_space()
+void eat_current_token_without_space(void)
 {
 	_eat_current_token(FALSE);
 }
@@ -232,8 +232,8 @@ void remove_macro(struct token_list* token)
 	return;
 }
 
-int macro_expression();
-int macro_variable()
+int macro_expression(void);
+int macro_variable(void)
 {
 	int value = 0;
 	struct macro_list* hold = lookup_macro(macro_token);
@@ -251,14 +251,14 @@ int macro_variable()
 	return value;
 }
 
-int macro_number()
+int macro_number(void)
 {
 	int result = strtoint(macro_token->s);
 	eat_current_token();
 	return result;
 }
 
-int macro_primary_expr()
+int macro_primary_expr(void)
 {
 	int defined_has_paren = FALSE;
 	int hold;
@@ -332,7 +332,7 @@ int macro_primary_expr()
 	}
 }
 
-int macro_additive_expr()
+int macro_additive_expr(void)
 {
 	int lhs = macro_primary_expr();
 	int hold;
@@ -383,7 +383,7 @@ int macro_additive_expr()
 	}
 }
 
-int macro_relational_expr()
+int macro_relational_expr(void)
 {
 	int lhs = macro_additive_expr();
 
@@ -423,7 +423,7 @@ int macro_relational_expr()
 	}
 }
 
-int macro_bitwise_expr()
+int macro_bitwise_expr(void)
 {
 	int rhs;
 	int lhs = macro_relational_expr();
@@ -463,12 +463,12 @@ int macro_bitwise_expr()
 	}
 }
 
-int macro_expression()
+int macro_expression(void)
 {
 	return macro_bitwise_expr();
 }
 
-void handle_define()
+void handle_define(void)
 {
 	struct macro_list* hold;
 	struct token_list* arg;
@@ -595,7 +595,7 @@ void handle_define()
 	}
 }
 
-void handle_undef()
+void handle_undef(void)
 {
 	eat_current_token();
 	remove_macro(macro_token);
@@ -640,7 +640,7 @@ void handle_error(int warning_p)
 	}
 }
 
-void macro_directive()
+void macro_directive(void)
 {
 	struct conditional_inclusion *t;
 	int result;
@@ -833,7 +833,7 @@ struct token_list* expand_macro_functions(struct token_list* expansion, struct t
 	return hold;
 }
 
-void eat_until_endif()
+void eat_until_endif(void)
 {
 	/* This #if block is nested inside of an #if block that needs to be dropped, lose EVERYTHING */
 	do
@@ -849,7 +849,7 @@ void eat_until_endif()
 	} while(!match("#endif", macro_token->s));
 }
 
-void eat_block()
+void eat_block(void)
 {
 	/* This conditional #if block is wrong, drop everything until the #elif/#else/#endif */
 	do
@@ -939,7 +939,7 @@ struct token_list* maybe_expand(struct token_list* token)
 	return hold4;
 }
 
-void preprocess()
+void preprocess(void)
 {
 	int start_of_line = TRUE;
 	macro_token = global_token;

--- a/cc_reader.c
+++ b/cc_reader.c
@@ -52,7 +52,7 @@ void just_seen(char* s)
 	vision = hold;
 }
 
-int grab_byte()
+int grab_byte(void)
 {
 	int c = fgetc(input);
 	if(10 == c) line = line + 1;
@@ -120,7 +120,7 @@ void clear_string(char* s)
 	}
 }
 
-void reset_hold_string()
+void reset_hold_string(void)
 {
 	clear_string(hold_string);
 	string_index = 0;

--- a/cc_spawn.c
+++ b/cc_spawn.c
@@ -501,6 +501,12 @@ void spawn_processes(int debug_flag, char* prefix, char* preprocessed_file, char
 	strcpy(M1_output, prefix);
 	strcat(M1_output, "/M1-macro-XXXXXX");
 	i = mkstemp(M1_output);
+
+	if(OBJECT_FILES_ONLY)
+	{
+		M1_output = destination;
+	}
+
 	if(-1 != i)
 	{
 		close(i);
@@ -518,6 +524,11 @@ void spawn_processes(int debug_flag, char* prefix, char* preprocessed_file, char
 	if(!match("", blood_output))
 	{
 		if(!DIRTY_MODE) remove(blood_output);
+	}
+
+	if(OBJECT_FILES_ONLY)
+	{
+		return;
 	}
 
 	/* Build the final binary */

--- a/gcc_req.h
+++ b/gcc_req.h
@@ -18,4 +18,4 @@
 // Exists only because gcc doesn't support naked Function pointers
 // And thus adds just enough support that M2-Plant can leverage the feature
 // in its self-host
-typedef void (*FUNCTION) ();
+typedef void (*FUNCTION) (void);

--- a/gcc_req.h
+++ b/gcc_req.h
@@ -15,7 +15,7 @@
  * along with M2-Planet.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Exists only because gcc doesn't support naked Function pointers
-// And thus adds just enough support that M2-Plant can leverage the feature
-// in its self-host
+/* Exists only because gcc doesn't support naked Function pointers
+ * And thus adds just enough support that M2-Plant can leverage the feature
+ * in its self-host */
 typedef void (*FUNCTION) (void);

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ BASE_ADDRESS:=$(shell get_machine --hex2)
 
 all: M2-Mesoplanet
 
-M2-Mesoplanet: bin results cc.h cc_reader.c cc_core.c cc_macro.c cc_env.c cc_spawn.c cc.c cc_globals.c cc_globals.h
+M2-Mesoplanet: bin cc.h cc_reader.c cc_core.c cc_macro.c cc_env.c cc_spawn.c cc.c cc_globals.c cc_globals.h
 	$(CC) $(CFLAGS) \
 	M2libc/bootstrappable.c \
 	cc_reader.c \
@@ -43,7 +43,7 @@ M2-Mesoplanet: bin results cc.h cc_reader.c cc_core.c cc_macro.c cc_env.c cc_spa
 	gcc_req.h \
 	-o bin/M2-Mesoplanet
 
-M2-boot: bin results cc.h cc_reader.c cc_core.c cc_macro.c cc_env.c cc_spawn.c cc.c cc_globals.c cc_globals.h
+M2-boot: bin cc.h cc_reader.c cc_core.c cc_macro.c cc_env.c cc_spawn.c cc.c cc_globals.c cc_globals.h
 	echo $(ARCH)
 	echo $(BLOOD_FLAG)
 	echo $(ENDIAN_FLAG)
@@ -110,9 +110,6 @@ clean-tmp:
 bin:
 	mkdir -p bin
 
-results:
-	mkdir -p test/results
-
 # tests
 test: M2-Mesoplanet
 	./test/test0000/run_test.sh
@@ -120,7 +117,6 @@ test: M2-Mesoplanet
 	./test/test0002/run_test.sh
 	./test/test0003/run_test.sh
 	./test/test0004/run_test.sh
-#	sha256sum -c test/test.answers
 
 
 # Generate test answers

--- a/makefile
+++ b/makefile
@@ -88,7 +88,11 @@ M2-boot: bin results cc.h cc_reader.c cc_core.c cc_macro.c cc_env.c cc_spawn.c c
 .PHONY: clean
 clean:
 	rm -rf bin/
-#	./test/test0000/cleanup.sh
+	rm -rf test/test0000/tmp
+	rm -rf test/test0001/tmp
+	rm -rf test/test0002/tmp
+	rm -rf test/test0003/tmp
+	rm -rf test/test0004/tmp
 
 .PHONY: clean-tmp
 clean-tmp:

--- a/makefile
+++ b/makefile
@@ -52,9 +52,14 @@ M2-boot: bin results cc.h cc_reader.c cc_core.c cc_macro.c cc_env.c cc_spawn.c c
 	-f M2libc/sys/types.h \
 	-f M2libc/stddef.h \
 	-f M2libc/${ARCH}/linux/fcntl.c \
+	-f M2libc/fcntl.c \
 	-f M2libc/${ARCH}/linux/unistd.c \
 	-f M2libc/${ARCH}/linux/sys/stat.c \
+	-f M2libc/sys/utsname.h \
+	-f M2libc/ctype.c \
 	-f M2libc/stdlib.c \
+	-f M2libc/stdarg.h \
+	-f M2libc/stdio.h \
 	-f M2libc/stdio.c \
 	-f M2libc/string.c \
 	-f M2libc/bootstrappable.c \
@@ -79,7 +84,7 @@ M2-boot: bin results cc.h cc_reader.c cc_core.c cc_macro.c cc_env.c cc_spawn.c c
 	hex2 --architecture ${ARCH} \
 	${ENDIAN_FLAG} \
 	--base-address ${BASE_ADDRESS} \
-	-f ../M2libc/${ARCH}/ELF-${ARCH}-debug.hex2 \
+	-f ./M2libc/${ARCH}/ELF-${ARCH}-debug.hex2 \
 	-f ./bin/M2-Mesoplanet-1.hex2 \
 	-o ./bin/M2-Mesoplanet
 

--- a/makefile
+++ b/makefile
@@ -110,6 +110,7 @@ test: M2-Mesoplanet
 	./test/test0001/run_test.sh
 	./test/test0002/run_test.sh
 	./test/test0003/run_test.sh
+	./test/test0004/run_test.sh
 #	sha256sum -c test/test.answers
 
 

--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ PACKAGE = m2-mesoplanet
 
 # C compiler settings
 CC?=gcc
-CFLAGS:=$(CFLAGS) -D_GNU_SOURCE -O0 -std=c99 -ggdb
+CFLAGS:=$(CFLAGS) -D_GNU_SOURCE -O0 -std=c99 -ggdb -Wall -Wextra -Wstrict-prototypes
 ARCH:=$(shell get_machine)
 BLOOD_FLAG:=$(shell get_machine --blood)
 ENDIAN_FLAG:=$(shell get_machine --endian)

--- a/test/test0004/f.c
+++ b/test/test0004/f.c
@@ -1,2 +1,7 @@
 
-int f() { return 0; }
+#include <stdio.h>
+
+int f() {
+	printf("Hello world\n");
+	return 0;
+}

--- a/test/test0004/f.c
+++ b/test/test0004/f.c
@@ -1,0 +1,2 @@
+
+int f() { return 0; }

--- a/test/test0004/f_no_print.c
+++ b/test/test0004/f_no_print.c
@@ -1,0 +1,3 @@
+
+int f() { return 0; }
+

--- a/test/test0004/main.c
+++ b/test/test0004/main.c
@@ -1,0 +1,6 @@
+
+int f();
+
+int main() {
+	return f();
+}

--- a/test/test0004/run_test.sh
+++ b/test/test0004/run_test.sh
@@ -57,4 +57,97 @@ if [ ! -f ${TMPDIR}/a.out ]; then
 	exit 6
 fi
 
+# Two object files with one stdio.h
+
+"${BINDIR}/M2-Mesoplanet" \
+	test/test0004/main.c \
+	test/test0004/f.c \
+	-o ${TMPDIR}/both_source \
+	|| exit 7
+
+OUTPUT=$("${TMPDIR}/both_source") || exit 8
+if [ "$OUTPUT" != "Hello world" ]; then
+	exit 9
+fi
+
+"${BINDIR}/M2-Mesoplanet" \
+	test/test0004/main.c \
+	test/test0004/tmp/f.o \
+	-o ${TMPDIR}/main_source \
+	|| exit 10
+
+OUTPUT=$("${TMPDIR}/main_source") || exit 11
+if [ "$OUTPUT" != "Hello world" ]; then
+	exit 12
+fi
+
+"${BINDIR}/M2-Mesoplanet" \
+	test/test0004/tmp/main.o \
+	test/test0004/f.c \
+	-o ${TMPDIR}/f_source \
+	|| exit 13
+
+OUTPUT=$("${TMPDIR}/f_source") || exit 14
+if [ "$OUTPUT" != "Hello world" ]; then
+	exit 15
+fi
+
+"${BINDIR}/M2-Mesoplanet" \
+	test/test0004/tmp/main.o \
+	test/test0004/tmp/f.o \
+	--dirty-mode \
+	-o ${TMPDIR}/double_object_file \
+	|| exit 16
+
+OUTPUT=$("${TMPDIR}/double_object_file") || exit 17
+if [ "$OUTPUT" != "Hello world" ]; then
+	exit 18
+fi
+
+# Two object files without any stdio.h
+
+"${BINDIR}/M2-Mesoplanet" \
+	-c \
+	"test/test0004/f_no_print.c" \
+	-o "${TMPDIR}/f_no_print.o" \
+	|| exit 19
+
+if [ ! -f ${TMPDIR}/f_no_print.o ]; then
+	echo "FAILURE: ${TMPDIR}/f_no_print.o not found!"
+	exit 20
+fi
+
+"${BINDIR}/M2-Mesoplanet" \
+	test/test0004/main.c \
+	test/test0004/f_no_print.c \
+	-o ${TMPDIR}/both_source_no_print \
+	|| exit 21
+
+"${TMPDIR}/both_source_no_print" || exit 22
+
+"${BINDIR}/M2-Mesoplanet" \
+	test/test0004/main.c \
+	test/test0004/tmp/f_no_print.o \
+	-o ${TMPDIR}/main_source_no_print \
+	|| exit 23
+
+"${TMPDIR}/main_source_no_print" || exit 24
+
+"${BINDIR}/M2-Mesoplanet" \
+	test/test0004/tmp/main.o \
+	test/test0004/f_no_print.c \
+	-o ${TMPDIR}/f_source_no_print \
+	|| exit 25
+
+"${TMPDIR}/f_source_no_print" || exit 26
+
+"${BINDIR}/M2-Mesoplanet" \
+	test/test0004/tmp/main.o \
+	test/test0004/tmp/f_no_print.o \
+	--dirty-mode \
+	-o ${TMPDIR}/double_object_file_no_print \
+	|| exit 27
+
+"${TMPDIR}/double_object_file_no_print" || exit 28
+
 exit 0

--- a/test/test0004/run_test.sh
+++ b/test/test0004/run_test.sh
@@ -1,0 +1,47 @@
+#! /bin/sh
+## Copyright (C) 2017 Jeremiah Orians
+## Copyright (C) 2020-2021 deesix <deesix@tuta.io>
+## This file is part of M2-Planet.
+##
+## M2-Planet is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## M2-Planet is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with M2-Planet.  If not, see <http://www.gnu.org/licenses/>.
+
+set -x
+
+TMPDIR="test/test0004/tmp"
+
+mkdir -p ${TMPDIR}
+
+bin/M2-Mesoplanet \
+	-c \
+	-f test/test0004/main.c \
+	-o ${TMPDIR}/main.o \
+	|| exit 1
+
+bin/M2-Mesoplanet \
+	-c \
+	-f test/test0004/f.c \
+	-o ${TMPDIR}/f.o \
+	|| exit 2
+
+if [ ! -f ${TMPDIR}/f.o ]; then
+	echo "FAILURE: ${TMPDIR}/f.o not found!"
+	exit 3
+fi
+
+if [ ! -f ${TMPDIR}/main.o ]; then
+	echo "FAILURE: ${TMPDIR}/main.o not found!"
+	exit 4
+fi
+
+exit 0

--- a/test/test0004/run_test.sh
+++ b/test/test0004/run_test.sh
@@ -19,20 +19,22 @@
 set -x
 
 TMPDIR="test/test0004/tmp"
+BINDIR="$PWD/bin"
 
 mkdir -p ${TMPDIR}
 
-bin/M2-Mesoplanet \
+"${BINDIR}/M2-Mesoplanet" \
 	-c \
 	-f test/test0004/main.c \
 	-o ${TMPDIR}/main.o \
 	|| exit 1
 
-bin/M2-Mesoplanet \
+cd ${TMPDIR} && "${BINDIR}/M2-Mesoplanet" \
 	-c \
-	-f test/test0004/f.c \
-	-o ${TMPDIR}/f.o \
+	-f ../f.c \
 	|| exit 2
+
+cd -
 
 if [ ! -f ${TMPDIR}/f.o ]; then
 	echo "FAILURE: ${TMPDIR}/f.o not found!"
@@ -42,6 +44,17 @@ fi
 if [ ! -f ${TMPDIR}/main.o ]; then
 	echo "FAILURE: ${TMPDIR}/main.o not found!"
 	exit 4
+fi
+
+cd ${TMPDIR} && "${BINDIR}/M2-Mesoplanet" \
+	../f.c ../main.c \
+	|| exit 5
+
+cd -
+
+if [ ! -f ${TMPDIR}/a.out ]; then
+	echo "FAILURE: ${TMPDIR}/a.out not found!"
+	exit 6
 fi
 
 exit 0


### PR DESCRIPTION
Adds support for the `-c` CLI option which outputs a `.o` file. This is just the output of M2-Planet with the extension changed. I originally made it a hex1 file but this caused issues with the debug info was duplicated in every object file leading to incorrect debug info.


Also makes the `M2-boot` target work again. This is super helpful for ensuring that M2-Planet can actually build M2-Mesoplanet. I would like for `make test` to build both the GCC version and then the M2-Planet version and run the tests for both of them, but I'm unsure of how to do that in make without duplicating the list of tests.

Also some minor fixes and touchups.

@stikonas @oriansj 