### PR TITLE
Make multiple `-I` work correctly

### DIFF
--- a/cc.c
+++ b/cc.c
@@ -89,9 +89,18 @@ void prechecks(int argc, char** argv)
 			follow_includes = FALSE;
 			i+= 1;
 		}
-		else if(match(argv[i], "-I"))
+		else if(starts_with(argv[i], "-I"))
 		{
-			hold = argv[i+1];
+			int two_arguments = strlen(argv[i]) == 2;
+			if(two_arguments)
+			{
+				hold = argv[i+1];
+			}
+			else
+			{
+				hold = argv[i] + 2;
+			}
+
 			if(NULL == hold)
 			{
 				fputs("-I requires a PATH\n", stderr);
@@ -122,7 +131,14 @@ void prechecks(int argc, char** argv)
 				}
 				M2LIBC_PATH = hold;
 			}
-			i += 2;
+			if(two_arguments)
+			{
+				i += 2;
+			}
+			else
+			{
+				i += 1;
+			}
 		}
 		else if(match(argv[i], "-D"))
 		{
@@ -286,10 +302,18 @@ int main(int argc, char** argv, char** envp)
 			/* handled by precheck */
 			i += 2;
 		}
-		else if(match(argv[i], "-I"))
+		else if(starts_with(argv[i], "-I"))
 		{
 			/* Handled by precheck */
-			i += 2;
+			if(strlen(argv[i]) > 2)
+			{
+				/* If path in the same string as -I/mypath/here */
+				i += 1;
+			}
+			else
+			{
+				i += 2;
+			}
 		}
 		else if(match(argv[i], "-D"))
 		{

--- a/cc.c
+++ b/cc.c
@@ -181,6 +181,12 @@ int main(int argc, char** argv, char** envp)
 	setup_env();
 	if(1 <= DEBUG_LEVEL) fputs("Environment setup\n", stderr);
 
+	/* If this variable is set we treat calling the executable without arguments as an error. */
+	if(env_lookup("M2MESOPLANET_NEW_ARGUMENTLESS_BEHAVIOR") != NULL)
+	{
+		in = NULL;
+	}
+
 	M2LIBC_PATH = env_lookup("M2LIBC_PATH");
 	if(NULL == M2LIBC_PATH) M2LIBC_PATH = "./M2libc";
 	else if(1 <= DEBUG_LEVEL)
@@ -317,6 +323,10 @@ int main(int argc, char** argv, char** envp)
 			/* strip things down */
 			debug_flag = FALSE;
 			i += 1;
+		}
+		else if(match(argv[i], "-"))
+		{
+			in = stdin;
 		}
 		else if(match(argv[i], "--temp-directory"))
 		{

--- a/cc.c
+++ b/cc.c
@@ -97,13 +97,31 @@ void prechecks(int argc, char** argv)
 				fputs("-I requires a PATH\n", stderr);
 				exit(EXIT_FAILURE);
 			}
-			if(1 <= DEBUG_LEVEL)
+
+			struct include_path_list* path = calloc(1, sizeof(struct include_path_list));
+			path->path = hold;
+
+			/* We want the first path on the CLI to be the first path checked so it needs to be in the proper order. */
+			if(include_paths == NULL)
 			{
-				fputs("M2LIBC_PATH set by -I to ", stderr);
-				fputs(hold, stderr);
-				fputc('\n', stderr);
+				include_paths = path;
 			}
-			M2LIBC_PATH = hold;
+			else
+			{
+				include_paths->next = path;
+			}
+
+			/* For backwards compatibility the first include path sets M2LIBC_PATH */
+			if(M2LIBC_PATH == NULL)
+			{
+				if(1 <= DEBUG_LEVEL)
+				{
+					fputs("M2LIBC_PATH set by -I to ", stderr);
+					fputs(hold, stderr);
+					fputc('\n', stderr);
+				}
+				M2LIBC_PATH = hold;
+			}
 			i += 2;
 		}
 		else if(match(argv[i], "-D"))

--- a/cc.h
+++ b/cc.h
@@ -30,6 +30,7 @@ int match(char* a, char* b);
 void require(int bool, char* error);
 char* int2str(int x, int base, int signed_p);
 void reset_hold_string(void);
+int starts_with(char* str, char* needle);
 int ends_with(char* str, char* needle);
 void append_file_contents(FILE* f, FILE* appended_file);
 

--- a/cc.h
+++ b/cc.h
@@ -74,4 +74,10 @@ struct object_file_list
 	struct object_file_list* next;
 };
 
+struct include_path_list
+{
+	char* path;
+	struct include_path_list* next;
+};
+
 #include "cc_globals.h"

--- a/cc_core.c
+++ b/cc_core.c
@@ -65,6 +65,11 @@ void output_tokens(struct token_list *i, FILE* out)
 	}
 }
 
+int starts_with(char* str, char* needle)
+{
+	return strcmp(str, needle) == 0;
+}
+
 int ends_with(char* str, char* needle)
 {
 	size_t str_len = strlen(str);

--- a/cc_globals.c
+++ b/cc_globals.c
@@ -18,6 +18,8 @@
 
 struct object_file_list* extra_object_files;
 
+struct include_path_list* include_paths;
+
 /* What we are currently working on */
 struct token_list* global_token;
 

--- a/cc_globals.h
+++ b/cc_globals.h
@@ -18,6 +18,8 @@
 
 extern struct object_file_list* extra_object_files;
 
+extern struct include_path_list* include_paths;
+
 /* What we are currently working on */
 extern struct token_list* global_token;
 

--- a/cc_reader.c
+++ b/cc_reader.c
@@ -357,10 +357,14 @@ int include_file(int ch, int include_file)
 	/* Remove name from stream */
 	token = token->next;
 
+	if(match("stdio.h", new_filename + 1))
+	{
+		STDIO_USED = TRUE;
+	}
+
 	/* Try to open the file */
 	if('<' == new_filename[0])
 	{
-		if(match("stdio.h", new_filename + 1)) STDIO_USED = TRUE;
 		reset_hold_string();
 		strcat(hold_string, M2LIBC_PATH);
 		strcat(hold_string, "/");

--- a/cc_reader.c
+++ b/cc_reader.c
@@ -427,6 +427,19 @@ int include_file(int ch, int include_file)
 				strcat(hold_string, new_filename + 1);
 				new_file = fopen(hold_string, "r");
 			}
+
+			struct include_path_list* path = include_paths;
+			while(new_file == NULL && path != NULL)
+			{
+				reset_hold_string();
+
+				strcat(hold_string, path->path);
+				strcat(hold_string, "/");
+				strcat(hold_string, new_filename + 1);
+				new_file = fopen(hold_string, "r");
+
+				path = path->next;
+			}
 		}
 
 		strcat(new_filename, "\"");

--- a/makefile
+++ b/makefile
@@ -125,7 +125,11 @@ Generate-test-answers:
 	sha256sum test/test0000/tmp/return.c >| test/test0000/proof.answer
 	sha256sum test/test0001/tmp/return.c >| test/test0001/proof.answer
 	sha256sum test/test0002/tmp/macro_functions.c >| test/test0002/proof.answer
-	sha256sum test/test0003/tmp/include_paths1.c test/test0003/tmp/include_paths2.c  >| test/test0003/proof.answer
+	sha256sum test/test0003/tmp/include_paths1.c \
+		test/test0003/tmp/include_paths2.c \
+		test/test0003/tmp/include_paths3.c \
+		test/test0003/tmp/include_paths4.c \
+		>| test/test0003/proof.answer
 
 DESTDIR:=
 PREFIX:=/usr/local

--- a/makefile
+++ b/makefile
@@ -125,7 +125,7 @@ Generate-test-answers:
 	sha256sum test/test0000/tmp/return.c >| test/test0000/proof.answer
 	sha256sum test/test0001/tmp/return.c >| test/test0001/proof.answer
 	sha256sum test/test0002/tmp/macro_functions.c >| test/test0002/proof.answer
-	sha256sum test/test0003/tmp/include_paths1.c >| test/test0003/proof.answer
+	sha256sum test/test0003/tmp/include_paths1.c test/test0003/tmp/include_paths2.c  >| test/test0003/proof.answer
 
 DESTDIR:=
 PREFIX:=/usr/local

--- a/test/test0003/directory/g.h
+++ b/test/test0003/directory/g.h
@@ -1,0 +1,2 @@
+
+int g() { return 0; }

--- a/test/test0003/include_paths2.c
+++ b/test/test0003/include_paths2.c
@@ -1,0 +1,6 @@
+
+#include "directory/g.h"
+
+int main() {
+  return g();
+}

--- a/test/test0003/include_paths3.c
+++ b/test/test0003/include_paths3.c
@@ -1,0 +1,6 @@
+
+#include "g.h"
+
+int main() {
+  return g();
+}

--- a/test/test0003/include_paths4.c
+++ b/test/test0003/include_paths4.c
@@ -1,0 +1,6 @@
+
+#include "g.h"
+
+int main() {
+  return g();
+}

--- a/test/test0003/include_paths5.c
+++ b/test/test0003/include_paths5.c
@@ -1,0 +1,6 @@
+
+#include "stdio.h"
+
+int main() {
+	printf("Hello world!\n");
+}

--- a/test/test0003/path4dir/g.h
+++ b/test/test0003/path4dir/g.h
@@ -1,0 +1,4 @@
+
+#include "f.h"
+
+int g() { return f(); }

--- a/test/test0003/proof.answer
+++ b/test/test0003/proof.answer
@@ -1,2 +1,4 @@
 0e466d3bc7892fb7347fe195b4b24c103e0d5d24e61c72d15d3594c4d2e60f50  test/test0003/tmp/include_paths1.c
 c53fe1866e9923066f600c977ec0170e124eef64cb6788b2b6a9f7fda86b4dc2  test/test0003/tmp/include_paths2.c
+f4faa3469bdf04b7750c04e76c3099ccdef7cbfa65c305ec8e20d25fea0b8d04  test/test0003/tmp/include_paths3.c
+4a3f2e93eda0615405a8393e88cedcb5a61b2ea2db905a0a02d9e9d1b22ae687  test/test0003/tmp/include_paths4.c

--- a/test/test0003/proof.answer
+++ b/test/test0003/proof.answer
@@ -1,1 +1,2 @@
 0e466d3bc7892fb7347fe195b4b24c103e0d5d24e61c72d15d3594c4d2e60f50  test/test0003/tmp/include_paths1.c
+c53fe1866e9923066f600c977ec0170e124eef64cb6788b2b6a9f7fda86b4dc2  test/test0003/tmp/include_paths2.c

--- a/test/test0003/run_test.sh
+++ b/test/test0003/run_test.sh
@@ -66,5 +66,13 @@ bin/M2-Mesoplanet \
 	-o ${TMPDIR}/include_paths5.c \
 	|| exit 7
 
+bin/M2-Mesoplanet \
+	-IM2libc \
+	test/test0003/include_paths5.c \
+	-o ${TMPDIR}/include_paths6 \
+	|| exit 7
+
+${TMPDIR}/include_paths6 || exit 8
+
 sha256sum -c test/test0003/proof.answer || exit 2
 exit 0

--- a/test/test0003/run_test.sh
+++ b/test/test0003/run_test.sh
@@ -58,5 +58,13 @@ bin/M2-Mesoplanet \
 	-o ${TMPDIR}/include_paths4.c \
 	|| exit 6
 
+bin/M2-Mesoplanet \
+	-E \
+	-Itest/test0003 \
+	-Itest/test0003/directory \
+	test/test0003/include_paths4.c \
+	-o ${TMPDIR}/include_paths5.c \
+	|| exit 7
+
 sha256sum -c test/test0003/proof.answer || exit 2
 exit 0

--- a/test/test0003/run_test.sh
+++ b/test/test0003/run_test.sh
@@ -29,5 +29,11 @@ bin/M2-Mesoplanet \
 	-o ${TMPDIR}/include_paths1.c \
 	|| exit 1
 
+bin/M2-Mesoplanet \
+	-E \
+	test/test0003/include_paths2.c \
+	-o ${TMPDIR}/include_paths2.c \
+	|| exit 3
+
 sha256sum -c test/test0003/proof.answer || exit 2
 exit 0

--- a/test/test0003/run_test.sh
+++ b/test/test0003/run_test.sh
@@ -35,5 +35,28 @@ bin/M2-Mesoplanet \
 	-o ${TMPDIR}/include_paths2.c \
 	|| exit 3
 
+bin/M2-Mesoplanet \
+	-E \
+	-I test/test0003/directory \
+	test/test0003/include_paths3.c \
+	-o ${TMPDIR}/include_paths3.c \
+	|| exit 4
+
+bin/M2-Mesoplanet \
+	-E \
+	-I test/test0003 \
+	-I test/test0003/directory \
+	test/test0003/include_paths3.c \
+	-o ${TMPDIR}/include_paths3.c \
+	|| exit 5
+
+bin/M2-Mesoplanet \
+	-E \
+	-I test/test0003 \
+	-I test/test0003/directory \
+	test/test0003/include_paths4.c \
+	-o ${TMPDIR}/include_paths4.c \
+	|| exit 6
+
 sha256sum -c test/test0003/proof.answer || exit 2
 exit 0


### PR DESCRIPTION
This makes M2-Mesoplanet work more like a normal C compiler.

* Multiple `-I` flags now correctly add multiple search paths. Fixes (partially, it's not entirely correct yet) https://github.com/oriansj/M2-Mesoplanet/issues/11.
* Paths are searched in order.
* Paths are only searched for quote style includes (`#include "this"`)
	* The angle bracket style includes have some hefty implicit behavior in them that probably wouldn't mix well with a more general approach to includes. IMO with time we should remove all the special cases and just have things work like a normal C compiler, but this would be a breaking change.
* Standard library paths can now be found through quote style includes if `M2libc` is added to the search path with `-I`.
* If the environment variable `M2MESOPLANET_NEW_ARGUMENTLESS_BEHAVIOR` is set calling `M2-Mesoplanet` without arguments will be an error instead of the way to accept input from stdin. Passing `-` as an argument now means accept from stdin both with and without this env var set. Fixes https://github.com/oriansj/M2-Mesoplanet/issues/18.

@stikonas @oriansj 
